### PR TITLE
fix SQL error while using &filters with tv-parameters containing "-" in ...

### DIFF
--- a/core/DocLister.abstract.php
+++ b/core/DocLister.abstract.php
@@ -280,7 +280,7 @@ abstract class DocLister
         }
         $table = $this->_table[$name];
         if(!empty($alias) && is_scalar($alias)){
-            $table .= " as ".$alias;
+            $table .= " as `".$alias."`";
         }
         return $table;
     }


### PR DESCRIPTION
...their names

[[DocLister? &parents=`...` &tpl=`...` &filters=`AND(tv:top-main:is:1)`]] - валится с ошибкой SQL-запроса
