### PR TITLE
Фикс ошибки SQL запроса

### DIFF
--- a/assets/snippets/DocLister/core/filterDocLister.abstract.php
+++ b/assets/snippets/DocLister/core/filterDocLister.abstract.php
@@ -140,19 +140,19 @@ abstract class filterDocLister
                 break;
             case '>':
             case 'gt':
-                $output .= ' > ' . floatval($value);
+                $output .= ' > ' . str_replace(',','.',floatval($value));
                 break;
             case '<':
             case 'lt':
-                $output .= ' < ' . floatval($value);
+                $output .= ' < ' . str_replace(',','.',floatval($value));
                 break;
             case '<=':
             case 'elt':
-                $output .= ' <= ' . floatval($value);
+                $output .= ' <= ' . str_replace(',','.',floatval($value));
                 break;
             case '>=':
             case 'egt':
-                $output .= ' >= ' . floatval($value);
+                $output .= ' >= ' . str_replace(',','.',floatval($value));
                 break;
             case '%':
             case 'like':


### PR DESCRIPTION
При некоторых настройках локали floatval($value) возвращает значение в виде #,## (с десятичной запятой), что ломает sql-запрос.