### PR TITLE
Update tv.extender.inc

### DIFF
--- a/assets/snippets/DocLister/core/extender/tv.extender.inc
+++ b/assets/snippets/DocLister/core/extender/tv.extender.inc
@@ -180,6 +180,7 @@ class tv_DL_Extender extends extDocLister
                 $TVnames = array();
             }
             $matches = explode(",", $match[1]);
+            sort($matches);
             $sortType = explode(",", $this->DocLister->getCFGDef('tvSortType'));
             $withDefault = explode(",", $this->DocLister->getCFGDef('tvSortWithDefault'));
             foreach ($matches as $i => &$item) {


### PR DESCRIPTION
Параметр tvSortType не работает, так как в php в качестве ключей выставляются неправильные значения, по крайней мере в той версии которую использую я. Какие значения выставляются я не проверял, но знаю точно, что функция sort эти ключи делает такими какими нужно.