### PR TITLE
Множественный вызов метода save()

### DIFF
--- a/assets/lib/MODxAPI/modResource.php
+++ b/assets/lib/MODxAPI/modResource.php
@@ -3,6 +3,7 @@ require_once('MODx.php');
 
 class modResource extends MODxAPI
 {
+    protected $mode = null;
     protected $default_field = array(
         'type' => 'document',
         'contentType' => 'text/html',
@@ -336,7 +337,6 @@ class modResource extends MODxAPI
         ), $fire_events);
 
         $fld = $this->toArray(null, null, null, false);
-	
         foreach ($this->default_field as $key => $value) {
             $tmp = $this->get($key);
             if ($this->newDoc && ( !is_int($tmp) && $tmp=='')) {
@@ -411,9 +411,12 @@ class modResource extends MODxAPI
                 }
             }
         }
-
+        if (!isset($this->mode)) {
+            $this->mode = $this->newDoc ? "new" : "upd";
+            $this->newDoc = false;
+        }
         $this->invokeEvent('OnDocFormSave', array(
-            'mode'  => $this->newDoc ? "new" : "upd",
+            'mode'  => $this->mode,
             'id'    => $this->id,
             'doc'   => $this->toArray(),
             'docObj'=> $this


### PR DESCRIPTION
Проблема воспроизводится так.
```
$doc->create()->save();
```
Если при вызове плагина на OnDocFormSave изменять свойства документа:
```
$docObj->set()->save();
```
То будет ошибка в запросе (из-за того что в методе Uset дублируются поля), да и сам запрос будет неверный (INSERT вместо UPDATE). Можно делать $docObj->close и $docObj->edit, но это лишний запрос на получение полей документа + если таких плагинов несколько, то условие $mode=='new' выполнится только в первом.

После правок можно делать такие вызовы, при этом $mode в плагины будет передаваться корректный. Глянь, не ломается ли что-нибудь глобально.