### PR TITLE
Неверное определение четности

### DIFF
--- a/assets/snippets/DocLister/core/DocLister.abstract.php
+++ b/assets/snippets/DocLister/core/DocLister.abstract.php
@@ -1009,7 +1009,7 @@ abstract class DocLister
     {
         $class = array();
 
-        $iterationName = ($i % 2 == 0) ? 'Odd' : 'Even';
+        $iterationName = ($i % 2 == 1) ? 'Odd' : 'Even';
         $tmp = strtolower($iterationName);
         $class[] = $this->getCFGDef($tmp . 'Class', $tmp);
 


### PR DESCRIPTION
Неверное определение четности при начальном $i равном 1, переданном в ф-цию uniformPrepare.
#239 