### PR TITLE
Формирование title в режиме api отличном от 1

### DIFF
--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -229,8 +229,8 @@ class site_contentDocLister extends DocLister
                 $row['date'] = strftime($this->getCFGDef('dateFormat', '%d.%b.%y %H:%M'),
                     $tmp + $this->modx->config['server_offset_time']);
             }
-            if (array('1') == $fields || in_array(array('menutitle', 'pagetitle'), $fields)) {
-                $row['title'] = ($row['menutitle'] == '' ? $row['pagetitle'] : $row['menutitle']);
+            if (array('1') == $fields || in_array('pagetitle', $fields)) {
+                $row['title'] = ($row['menutitle'] == '') ? $row['pagetitle'] : $row['menutitle'];
             }
             if ((bool)$this->getCFGDef('makeUrl', 1) && (array('1') == $fields || in_array(array('content', 'type'),
                         $fields))


### PR DESCRIPTION
Решение #246 для **title**

**title** формируется, если **&api=\`1\`**, или если в параметре **&api** задано хотя бы **pagetitle** (его достаточно для формирования title).

**Недостаток:** среди названий полей в параметре **&api** должно быть указано и **title**.

**Работающие примеры:**
&api=\`id,pagetitle,title\` (title сформируется из pagetitle)
&api=\`id,pagetitle,menutitle,title\` (title сформируется из menutitle, если он не пуст, иначе из pagetitle)

Примечание: кроме [условия в if](https://github.com/AgelxNash/DocLister/blob/master/assets/snippets/DocLister/core/controller/site_content.php#L232), исправлена [неверно расположенная скобка](https://github.com/AgelxNash/DocLister/blob/master/assets/snippets/DocLister/core/controller/site_content.php#L233).