### PR TITLE
Избавление от лишнего запроса

### DIFF
--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -268,6 +268,8 @@ class site_contentDocLister extends DocLister
         $out = 0;
         $sanitarInIDs = $this->sanitarIn($this->IDs);
         if ($sanitarInIDs != "''" || $this->getCFGDef('ignoreEmpty', '0')) {
+            $q_true = $this->getCFGDef('ignoreEmpty', '0');
+            $q_true = $q_true ? $q_true : $this->getCFGDef('idType', 'parents') == 'parents';
             $where = $this->getCFGDef('addWhereList', '');
             $where = sqlHelper::trimLogicalOp($where);
             $where = ($where ? $where . ' AND ' : '') . $this->_filters['where'];
@@ -280,6 +282,9 @@ class site_contentDocLister extends DocLister
             $whereArr = array();
             if (!$this->getCFGDef('showNoPublish', 0)) {
                 $whereArr[] = "c.deleted=0 AND c.published=1";
+            }
+            else{
+                $q_true = 1;
             }
 
             $tbl_site_content = $this->getTable('site_content', 'c');
@@ -315,6 +320,8 @@ class site_contentDocLister extends DocLister
             $from = $tbl_site_content . " " . $this->_filters['join'];
             $where = sqlHelper::trimLogicalOp($where);
 
+            $q_true = $q_true ? $q_true : trim($where) != 'WHERE';
+
             if (trim($where) != 'WHERE') {
                 $where .= " AND ";
             }
@@ -329,7 +336,9 @@ class site_contentDocLister extends DocLister
             $sort = $this->SortOrderSQL("if(c.pub_date=0,c.createdon,c.pub_date)");
             list($from) = $this->injectSortByTV($from, $sort);
 
-            if ( $this->getCFGDef('idType', 'parents') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') || $group != 'GROUP BY c.id' ){
+            $q_true = $q_true ? $q_true : $group != 'GROUP BY c.id';
+
+            if ( $q_true ){
                 $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
                 $out = $this->modx->db->getValue($rs);
             }

--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -329,11 +329,11 @@ class site_contentDocLister extends DocLister
             $sort = $this->SortOrderSQL("if(c.pub_date=0,c.createdon,c.pub_date)");
             list($from) = $this->injectSortByTV($from, $sort);
             
-            if ( $this->getCFGDef('idType', 'parents') == 'parents' || $this->getCFGDef('filters') ){
+            if ( $this->getCFGDef('idType') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') ){
                 $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
                 $out = $this->modx->db->getValue($rs);
             }
-            else{
+            else {
                 $out = count($this->IDs);
             }
         }

--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -329,7 +329,7 @@ class site_contentDocLister extends DocLister
             $sort = $this->SortOrderSQL("if(c.pub_date=0,c.createdon,c.pub_date)");
             list($from) = $this->injectSortByTV($from, $sort);
 
-            if ( $this->getCFGDef('idType') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') || $group != 'GROUP BY c.id' ){
+            if ( $this->getCFGDef('idType', 'parents') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') || $group != 'GROUP BY c.id' ){
                 $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
                 $out = $this->modx->db->getValue($rs);
             }

--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -328,9 +328,14 @@ class site_contentDocLister extends DocLister
             $group = $this->getGroupSQL($this->getCFGDef('groupBy', 'c.id'));
             $sort = $this->SortOrderSQL("if(c.pub_date=0,c.createdon,c.pub_date)");
             list($from) = $this->injectSortByTV($from, $sort);
-
-            $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
-            $out = $this->modx->db->getValue($rs);
+            
+            if ( $this->getCFGDef('idType', 'parents') == 'parents' || $this->getCFGDef('filters') ){
+                $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
+                $out = $this->modx->db->getValue($rs);
+            }
+            else{
+                $out = count($this->IDs);
+            }
         }
 
         return $out;

--- a/assets/snippets/DocLister/core/controller/site_content.php
+++ b/assets/snippets/DocLister/core/controller/site_content.php
@@ -328,8 +328,8 @@ class site_contentDocLister extends DocLister
             $group = $this->getGroupSQL($this->getCFGDef('groupBy', 'c.id'));
             $sort = $this->SortOrderSQL("if(c.pub_date=0,c.createdon,c.pub_date)");
             list($from) = $this->injectSortByTV($from, $sort);
-            
-            if ( $this->getCFGDef('idType') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') ){
+
+            if ( $this->getCFGDef('idType') == 'parents' || $this->getCFGDef('ignoreEmpty') || $this->getCFGDef('filters') || $this->getCFGDef('addWhereList') || $group != 'GROUP BY c.id' ){
                 $rs = $this->dbQuery("SELECT count(*) FROM (SELECT count(*) FROM {$from} {$where} {$group}) as `tmp`");
                 $out = $this->modx->db->getValue($rs);
             }


### PR DESCRIPTION
Если использовать параметр documents, при этом не задействовать параметр filters, то смысла в запросе получения числа передаваемых идентификаторов нет. Так при числе 19к ресурсов данный запрос отнимает 0.2 секунды.