### PR TITLE
Коррекция для parents

### DIFF
--- a/assets/snippets/DocLister/core/DocLister.abstract.php
+++ b/assets/snippets/DocLister/core/DocLister.abstract.php
@@ -230,7 +230,7 @@ abstract class DocLister
                 case 'parents':
                 default:
                     $cfg['idType'] = "parents";
-                    if (($IDs = $this->getCFGDef('parents')) === null) {
+                    if (($IDs = $this->getCFGDef('parents', '')) === '') {
                         $IDs = $this->getCurrentMODXPageID();
                     }
                     break;


### PR DESCRIPTION
Если параметр &parents есть и он пустой, то вернёт пустое значение и родителем будет  текущая страница