### PR TITLE
Custom friendly url

### DIFF
--- a/assets/snippets/DocLister/core/extender/paginate.extender.inc
+++ b/assets/snippets/DocLister/core/extender/paginate.extender.inc
@@ -213,6 +213,7 @@ class paginate_DL_Extender extends extDocLister
         $p->adjacents($this->DocLister->getCFGDef("pageAdjacents", 4));
         $p->target($this->getUrl());
         $p->currentPage($currentPage);
+        $p->urlFriendly = $this->DocLister->getCFGDef('PaginateUrlFriendly', null);
 
         switch (true) {
             case ($mode == 'offset' && $this->totalPage() > 1):

--- a/assets/snippets/DocLister/lib/DLpaginate.class.php
+++ b/assets/snippets/DocLister/lib/DLpaginate.class.php
@@ -25,6 +25,7 @@ class DLpaginate
     public $className = "pagination";
     public $parameterName = "page";
     public $urlF = null; //urlFriendly
+    public $urlFriendly = '';
 
     /**Buttons next and previous*/
     public $nextT = ' <a href="[+link+]">Next</a> ';
@@ -291,8 +292,8 @@ class DLpaginate
     {
         $flag = (strpos($this->target, '?') === false);
         $value = $this->getPageQuery($id);
-        if ($flag && !empty($this->urlF)) {
-            $out = str_replace($this->urlF, $value, $this->target);
+        if ($flag && !empty($this->urlFriendly)) {
+            $out = $this->target . $this->urlFriendly . $value;
         } else {
             $out = $this->target;
             if ($id > 1) {

--- a/assets/snippets/DocLister/lib/DLpaginateReversed.class.php
+++ b/assets/snippets/DocLister/lib/DLpaginateReversed.class.php
@@ -46,8 +46,8 @@ class DLpaginateReversed extends DLpaginate
     {
         $flag = (strpos($this->target, '?') === false);
         $value = $this->getPageQuery($id);
-        if ($flag && !empty($this->urlF)) {
-            $out = str_replace($this->urlF, $value, $this->target);
+        if ($flag && !empty($this->urlFriendly)) {
+            $out = $this->target . $this->urlFriendly . $value;
         } else {
             $out = $this->target;
             if ($id > 0 && $id < $this->total_pages) {


### PR DESCRIPTION
Добавляет возможность использования кастомных урлов в пагинации с переходами по страницам.
Использование.
Добавляется в параметр makePaginateUrl своя функция и урлы получают вид
site/p1, site/p2
```php
function custom_makePaginateUrl(
    $data,
    $modx,
    $_DL,
    $_eDL
) {
    $_DL->config->setConfig(array('PaginateUrlFriendly' => '/p'));
    return '/' . $modx->plaseholders['this_url'];
}
```