### PR TITLE
Prepare fix

### DIFF
--- a/assets/snippets/DocLister/core/extender/prepare.extender.inc
+++ b/assets/snippets/DocLister/core/extender/prepare.extender.inc
@@ -43,7 +43,7 @@ class prepare_DL_Extender extends extDocLister
             $params = $this->getParams($out);
             if (is_scalar($prepare)) {
                 $prepare = explode(",", $prepare);
-            } else if (!is_array($prepare)) {
+            } else if (!is_array($prepare) || is_callable($prepare)) {
                 $prepare = [$prepare];
             }
 


### PR DESCRIPTION
Фикс для ситуаций, когда передается метод класса в виде массива, например:
```php
'prepare' => ['SomeClass', 'prepare'],
или
'prepare' => [$someClass, 'prepare'],
```
Такой вариант также будет корректно обрабатываться.