### PR TITLE
FIX empty filter containsOne breaks SQL

### DIFF
--- a/assets/snippets/DocLister/core/filterDocLister.abstract.php
+++ b/assets/snippets/DocLister/core/filterDocLister.abstract.php
@@ -198,6 +198,10 @@ abstract class filterDocLister
                 } else {
                     $output = '';
                 }
+                // Make sure, the result is never () as this will break SQLs
+                if ($output == '()'){
+                    $output = '';
+                }
                 break;
             case 'in':
                 $output .= ' IN(' . $this->DocLister->sanitarIn($value, ',', true) . ')';


### PR DESCRIPTION
Если в фильтр containsOne передать пустой список, то на выходе получится WHERE ... AND () ... и ошибка SQL. Поправил.