### PR TITLE
Add new filters and fix work != and NOT IN filter

### DIFF
--- a/assets/snippets/DocLister/core/filterDocLister.abstract.php
+++ b/assets/snippets/DocLister/core/filterDocLister.abstract.php
@@ -142,8 +142,14 @@ abstract class filterDocLister
             case '!=':
             case 'no':
             case 'isnot':
-                $output .= " != '" . $this->modx->db->escape($value) . "'";
+                $output .= " != '" . $this->modx->db->escape($value) . "' OR " . $output . " IS NULL";
                 break;
+			case 'isnull':
+                $output .= " IS NULL";
+                break;
+            case 'isnotnull':
+                $output .= " IS NOT NULL";
+                break;	
             case '>':
             case 'gt':
                 $output .= ' > ' . str_replace(',', '.', floatval($value));
@@ -203,7 +209,7 @@ abstract class filterDocLister
                 $output .= ' IN(' . $this->DocLister->sanitarIn($value, ',', true) . ')';
                 break;
             case 'notin':
-                $output .= ' NOT IN(' . $this->DocLister->sanitarIn($value, ',', true) . ')';
+                $output .= ' NOT IN(' . $this->DocLister->sanitarIn($value, ',', true) . ') OR ' . $output . ' IS NULL';
                 break;
             default:
                 $output = '';


### PR DESCRIPTION
Мне пару раз были необходимы фильтры IS NULL и IS NOT NULL. В целом это не критично их отсутствие.
А вот с != выяснилось, что в определённых условиях. Если запрос выглядит как **filed != 1**, а значением filed является NULL, то эти строки всё-равно игнорируются. По этому рекомендуется добавить проверку на то что это поле является NULL.