### PR TITLE
Правка бага генерации урла для только что созданного документа

### DIFF
--- a/assets/lib/MODxAPI/modResource.php
+++ b/assets/lib/MODxAPI/modResource.php
@@ -633,6 +633,9 @@ class modResource extends MODxAPI
             'docObj' => $this
         ), $fire_events);
 
+
+        $this->modx->getAliasListing($this->id);
+
         if ($clearCache) {
             $this->clearCache($fire_events);
         }


### PR DESCRIPTION
Если "Использовать AliasListing только для Папок [(aliaslistingfolder)] стоит Да" и мы создали ресурс, то makeUrl

вернет /{doc_id}.html из за отсутствия записи в $modx->aliasListing