### PR TITLE
Исправление бага из получением полей из таблицы web_user_settings

### DIFF
--- a/assets/lib/MODxAPI/modUsers.php
+++ b/assets/lib/MODxAPI/modUsers.php
@@ -188,6 +188,7 @@ class modUsers extends MODxAPI
                 $this->userIdCache['attribute.internalKey'] = $this->getID();
                 $this->userIdCache['attribute.email'] = $this->get('email');
                 $this->userIdCache['user.username'] = $this->get('username');
+                $this->loadUserSettings();
                 $this->store($this->toArray());
                 unset($this->field['id']);
                 unset($this->field['internalKey']);
@@ -195,6 +196,16 @@ class modUsers extends MODxAPI
         }
 
         return $this;
+    }
+
+    protected function loadUserSettings()
+    {
+        $webUser = $this->getID();
+
+        if (!empty($webUser)) {
+            $settings = $this->modx->db->makeArray($this->modx->db->select('*', $this->makeTable('web_user_settings'), "webuser = {$webUser}"));
+            $this->fromArray(array_column($settings,'setting_value','setting_name'));
+        }
     }
 
     /**


### PR DESCRIPTION
Был баг, поля из таблицы web_user_settings недоступные через метод get, так как при редактировании пользователя их мы из таблицы  не грузим
Написал метод, который при редактировании пользователя подгрузит доп поля из таблицы web_user_settings