### PR TITLE
fix initialize of extender

### DIFF
--- a/assets/snippets/DocLister/core/controller/onetable.php
+++ b/assets/snippets/DocLister/core/controller/onetable.php
@@ -55,6 +55,8 @@ class onetableDocLister extends DocLister
             $extCommentsCount->init($this);
         }
 
+        $this->getExtender($this->getCFGDef('extender', ""), false, true)->init($this);
+
         $type = $this->getCFGDef('idType', 'parents');
         $this->_docs = ($type == 'parents') ? $this->getChildrenList() : $this->getDocList();
 


### PR DESCRIPTION
У меня не заработал вариант использования сниппета `DocLister` с собственным расширением `foobar`: 
```
[!DocLister? &controller=`onetable` &table=`catalog` &debug=`1`  &extender=`foobar`!]
```
Обнаружил, что расширение инстанцируется, но не инициализируется.

Мой патч исправляет это.