### PR TITLE
Удалил отключение вывода ошибок, если дебаг выключен

### DIFF
--- a/assets/snippets/DocLister/core/DocLister.abstract.php
+++ b/assets/snippets/DocLister/core/DocLister.abstract.php
@@ -398,8 +398,6 @@ abstract class DocLister
             if (is_null($this->debug)) {
                 $this->debug = new xNop();
                 $this->_debugMode = 0;
-                error_reporting(0);
-                ini_set('display_errors', 0);
             }
         }
     }


### PR DESCRIPTION
Это же настраивается в конфигурации сайта, зачем это здесь?
Мучился с одним сайтом, показывает 500 ошибку, а в лог ничего не пишет. Настроил показ всех ошибок, затем убрал уже в парсере вообще обработку ошибок, все равно ничего не выводит. А оказалось, что еще и доклистер зачем то все ошибки глушит.