### PR TITLE
Changed private __wakeup to public to make DocLister complatible with PHP8

### DIFF
--- a/assets/lib/Helpers/Assets.php
+++ b/assets/lib/Helpers/Assets.php
@@ -61,7 +61,7 @@ class AssetsHelper
      *
      * @return void
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 

--- a/assets/lib/Helpers/FS.php
+++ b/assets/lib/Helpers/FS.php
@@ -52,7 +52,7 @@ class FS
      *
      * @return void
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 

--- a/assets/snippets/DocLister/lib/DLTemplate.class.php
+++ b/assets/snippets/DocLister/lib/DLTemplate.class.php
@@ -77,7 +77,7 @@ if (!class_exists('\\DLTemplate')) {
          *
          * @return void
          */
-        private function __wakeup()
+        public function __wakeup()
         {
         }
 


### PR DESCRIPTION
Hi,
This is just a minor fix that changes the magic `__wakeup()` functions to public. This is necessary for PHP8 compatibility, see https://www.php.net/manual/en/language.oop5.magic.php

This pull request solves AgelxNash/DocLister#370