### PR TITLE
PHP 8.0 fix (E_WARNING)

### DIFF
--- a/assets/snippets/DocLister/lib/DLTemplate.class.php
+++ b/assets/snippets/DocLister/lib/DLTemplate.class.php
@@ -77,8 +77,9 @@ if (!class_exists('\\DLTemplate')) {
          *
          * @return void
          */
-        private function __wakeup()
+        public function __wakeup()
         {
+            return;
         }
 
         public function getTemplatePath()


### PR DESCRIPTION
Все магические методы, за исключением __construct(), __destruct() и __clone(), ДОЛЖНЫ быть объявлены как public, в противном случае будет вызвана ошибка уровня E_WARNING. До PHP 8.0.0 для магических методов __sleep(), __wakeup(), __serialize(), __unserialize() и __set_state() не выполнялась проверка.