### PR TITLE
Added check whether array has key to avoid PHP8 error

### DIFF
--- a/assets/snippets/DocLister/core/DocLister.abstract.php
+++ b/assets/snippets/DocLister/core/DocLister.abstract.php
@@ -1058,7 +1058,7 @@ abstract class DocLister
             $data[$this->getCFGDef("sysKey", "dl") . '.is_last'] = 0;
         }
 
-        if ($this->modx->documentIdentifier == $data['id']) {
+        if (array_key_exists('id', $data) && $this->modx->documentIdentifier == $data['id']) {
             $this->renderTPL = $this->getCFGDef('tplCurrent', $this->renderTPL);
             $data[$this->getCFGDef(
                 "sysKey",


### PR DESCRIPTION
I added a necessary check to see whether the array `$id` has key `'id'`. If the key does not exists, then PHP8 raises Warning, as opposed to Notice in previous versions, see https://www.php.net/manual/en/migration80.incompatible.php