### PR TITLE
fix problem with old param name and config in json

### DIFF
--- a/assets/snippets/DocLister/snippet.DLCrumbs.php
+++ b/assets/snippets/DocLister/snippet.DLCrumbs.php
@@ -50,6 +50,13 @@ if (!empty($_parents) && count($_parents) >= (empty($minDocs) ? 0 : (int) $minDo
             'documents' => implode(",", $_parents),
         ]
     );
+
+    // fix problem with old param name and config in json
+    if (isset($_options['ownerTPL'])) {
+        $_options['ownerTpl'] = $_options['ownerTPL'];
+        unset($_options['ownerTPL']);
+    }
+
     $_out = $modx->runSnippet("DocLister", $_options);
 }
 

--- a/assets/snippets/DocLister/snippet.DLSitemap.php
+++ b/assets/snippets/DocLister/snippet.DLSitemap.php
@@ -1,11 +1,17 @@
 <?php
-include_once(MODX_BASE_PATH . 'assets/lib/APIHelpers.class.php');
+include_once MODX_BASE_PATH . 'assets/lib/APIHelpers.class.php';
 
 if (!isset($params['config'])) {
     $params['config'] = 'sitemap:core';
 }
 if (!isset($schema)) {
     $schema = 'https://www.sitemaps.org/schemas/sitemap/0.9';
+}
+
+// fix problem with old param name and config in json
+if (isset($params['ownerTPL'])) {
+    $params['ownerTpl'] = $params['ownerTPL'];
+    unset($params['ownerTPL']);
 }
 
 if (!class_exists("DLSitemap")) {


### PR DESCRIPTION
Сниппет DLcrumbs просто вызывает DocLister, а уже в DocLister разбор параметра выглядит вот так:
$this->ownerTPL = $this->getCFGDef('ownerTpl', $this->getCFGDef('ownerTPL', ''));

То есть смотрит есть ли ownerTpl, а если нет, то смотрит есть ли ownerTPL и как будто всё хорошо, но есть одно НО - файл-json с настройками по умолчанию.

Этот json загружается при каждом вызове getCFGDef(), а передаваемые при вызове сниппета данные кладутся поверх того, что пришло из json и таким образом до проверки ownerTPL просто не доходит, так как данные для ownerTpl уже есть.

Такой json-файл есть только для crumbs, paginate и sitemap.

Фикс подменяет название параметра.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлена совместимость параметров конфигурации в системе обработки шаблонов. Нормализованы способы передачи параметров владельца шаблона для обеспечения корректной работы компонентов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->